### PR TITLE
Add preprocessor directives to make the code compile on Windows.

### DIFF
--- a/third_party/streamDM/streamDM/Common.h
+++ b/third_party/streamDM/streamDM/Common.h
@@ -27,7 +27,7 @@
 #include <stack>
 #include <iterator>
 #include <iostream>
-#include <fstream> 
+#include <fstream>
 #include <sstream>  
 #include <cmath>
 #include <ctime>
@@ -37,8 +37,16 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
+#include <stdint.h>
 
+#if defined(_WIN32) || defined(WIN32)
+// Windows work arounds for functions used from unistd.h.
+#include <io.h>
+#define access _access
+#define strcasecmp stricmp
+#else
 #include <unistd.h>
+#endif
 
 #include "utils/Utils.h"
 #include "utils/json.h"

--- a/third_party/streamDM/streamDM/utils/Utils.cpp
+++ b/third_party/streamDM/streamDM/utils/Utils.cpp
@@ -19,7 +19,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <algorithm>
-#include <unistd.h>
+#include <stdint.h>
 #include <cmath>
 
 #include <sys/types.h>

--- a/third_party/streamDM/streamDM/utils/Utils.h
+++ b/third_party/streamDM/streamDM/utils/Utils.h
@@ -25,6 +25,7 @@
 #include <map>
 #include <cmath>
 #include <iostream>
+#include "Common.h"
 
 using namespace std;
 

--- a/third_party/streamDM/streamDM/utils/jsoncpp.cpp
+++ b/third_party/streamDM/streamDM/utils/jsoncpp.cpp
@@ -74,7 +74,7 @@ license you like.
 
 
 #include "json.h"
-
+#include "Common.h"
 
 // //////////////////////////////////////////////////////////////////////
 // Beginning of content of file: src/lib_json/json_tool.h


### PR DESCRIPTION
The code used some functions from uinistd.h which have different names
on Windows, so add some #defines to make the code compile on Windows.

The code now compiles on Windows as per the instructions in the Readme.